### PR TITLE
Removed duplicate include.

### DIFF
--- a/examples/MyModule/mymodule.cpp
+++ b/examples/MyModule/mymodule.cpp
@@ -39,7 +39,6 @@
 #include "model_manager_impl.h"
 #include "nestmodule.h"
 #include "target_identifier.h"
-#include "model_manager_impl.h"
 
 // Includes from sli:
 #include "booldatum.h"


### PR DESCRIPTION
@markovg The `model_manager_impl.h` was now included twice. I removed the second include (includes of other nest files should be alphabetical). Could you merge this one in your repo, then I can merge on into NEST master.
